### PR TITLE
switch to alpine and use current versions

### DIFF
--- a/socat/Dockerfile
+++ b/socat/Dockerfile
@@ -1,17 +1,10 @@
-FROM debian:jessie
+FROM alpine:latest
 MAINTAINER Andrew Dunham <andrew@du.nham.ca>
 
-# Install build tools
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yy \
-        automake            \
-        build-essential     \
-        curl                \
-        git                 \
-        pkg-config
+RUN apk --update add build-base bash automake git curl linux-headers
 
 RUN mkdir /build
+RUN mkdir /output
 ADD . /build
 
 # This builds the program and copies it to /output


### PR DESCRIPTION
This PR switches the socat build to the much smaller alpine linux (already musl based) and updates all libraries to current versions