### PR TITLE
strace: update to 4.21

### DIFF
--- a/strace/arm/build.sh
+++ b/strace/arm/build.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -x
 
 
-STRACE_VERSION=4.10
+STRACE_VERSION=4.21
 
 
 function build_strace() {

--- a/strace/arm/strace.patch
+++ b/strace/arm/strace.patch
@@ -1,13 +1,13 @@
-diff --git 1/strace-4.10-orig/defs.h 2/strace-4.10/defs.h
-index dad4fe8..d1378ab 100644
---- 1/strace-4.10-orig/defs.h
-+++ 2/strace-4.10/defs.h
-@@ -54,6 +54,8 @@
+diff --git 1/strace-4.21-orig/defs.h 2/strace-4.21/defs.h
+--- 1/strace-4.21-orig/defs.h
++++ 2/strace-4.21/defs.h
+@@ -53,6 +53,9 @@
  #include <time.h>
  #include <sys/time.h>
- #include <sys/syscall.h>
+ 
 +#include <asm-generic/ioctl.h>
 +#include <linux/stat.h>
- 
- #ifndef HAVE_STRERROR
- const char *strerror(int);
++
+ #include "arch_defs.h"
+ #include "error_prints.h"
+ #include "gcc_compat.h"


### PR DESCRIPTION
Build log
```
make  all-am
make[3]: Entering directory '/build/strace-4.21/tests'
make[3]: Nothing to be done for 'all-am'.
make[3]: Leaving directory '/build/strace-4.21/tests'
make[2]: Leaving directory '/build/strace-4.21/tests'
make[1]: Leaving directory '/build/strace-4.21'
rm ioctlsort0.o ioctlsort0 ioctls_all0.h
+ arm-linux-musleabihf-strip strace
+ '[' -d /output ']'
++ uname
++ tr A-Z a-z
+ OUT_DIR=/output/linux/arm
+ mkdir -p /output/linux/arm
+ cp /build/strace-4.21/strace /output/linux/arm/
+ echo '** Finished **'
** Finished **
```

Tested on arm32 

```
~ # ./cache/strace -V
strace -- version 4.21
Copyright (c) 1991-2018 The strace developers <https://strace.io>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Optional features enabled: (none)
```