### PR TITLE
Update openssl verison

### DIFF
--- a/socat/build.sh
+++ b/socat/build.sh
@@ -7,7 +7,7 @@ set -x
 SOCAT_VERSION=1.7.3.2
 NCURSES_VERSION=6.0
 READLINE_VERSION=7.0
-OPENSSL_VERSION=1.1.0f
+OPENSSL_VERSION=1.1.1d
 
 function build_ncurses() {
     cd /build


### PR DESCRIPTION
Updating to `1.1.1d` fixes socat compilation error related to file globbing: 

```
+ cd openssl-1.1.0f
+ CC='/usr/bin/gcc -static'
+ ./Configure no-shared no-async linux-x86_64
"glob" is not exported by the File::Glob module
Can't continue after import errors at ./Configure line 17.
BEGIN failed--compilation aborted at ./Configure line 17.
```